### PR TITLE
DLS-11765 | Add individuals matching scope for HO NRC application

### DIFF
--- a/conf/scopes.json
+++ b/conf/scopes.json
@@ -1112,5 +1112,10 @@
     "key":"read:individuals-employments-ho-nrc",
     "name":"access individuals employment information for HO NRC",
     "description":"Scope for HO NRC to access employment and PAYE information on individuals"
+  },
+  {
+    "key":"read:individuals-matching-ho-nrc",
+    "name":"access individuals matching for HO NRC",
+    "description":"Scope for HO NRC to access individuals matching endpoints"
   }
 ]


### PR DESCRIPTION
New read only scope for HomeOffice NRC application to access individual matching endpoint.