### PR TITLE
APB-10433: Add write:relationships scope

### DIFF
--- a/conf/scopes.json
+++ b/conf/scopes.json
@@ -521,8 +521,8 @@
   },
   {
     "key":"write:relationships",
-    "name":"Modify relationships",
-    "description":"De-authorise an existing relationship"
+    "name":"De-authorise agent relationships",
+    "description":"Allows de-authorising an existing agent-client relationship"
   },
   {
     "key":"write:cancel-invitations",

--- a/conf/scopes.json
+++ b/conf/scopes.json
@@ -520,6 +520,11 @@
     "description":"Returns current status of relationship"
   },
   {
+    "key":"write:relationships",
+    "name":"Modify relationships",
+    "description":"De-authorise an existing relationship"
+  },
+  {
     "key":"write:cancel-invitations",
     "name":"Cancel Invitations",
     "description":"Cancel a pending invitation"


### PR DESCRIPTION
Title:
  APB-10433: Add write:relationships scope

  Body:

  - Adds new scope write:relationships to conf/scopes.json.
  - Required for agent-authorisation-api de-authorise endpoint (APB‑10433).
  - Matches OAS scope definition and Set‑7 action:domain guidance.